### PR TITLE
Initial draft of cloudformation templates

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,116 @@
+CC0 1.0 Universal
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator and
+subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for the
+purpose of contributing to a commons of creative, cultural and scientific
+works ("Commons") that the public can reliably and without fear of later
+claims of infringement build upon, modify, incorporate in other works, reuse
+and redistribute as freely as possible in any form whatsoever and for any
+purposes, including without limitation commercial purposes. These owners may
+contribute to the Commons to promote the ideal of a free culture and the
+further production of creative, cultural and scientific works, or to gain
+reputation or greater distribution for their Work in part through the use and
+efforts of others.
+
+For these and/or other purposes and motivations, and without any expectation
+of additional consideration or compensation, the person associating CC0 with a
+Work (the "Affirmer"), to the extent that he or she is an owner of Copyright
+and Related Rights in the Work, voluntarily elects to apply CC0 to the Work
+and publicly distribute the Work under its terms, with knowledge of his or her
+Copyright and Related Rights in the Work and the meaning and intended legal
+effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not limited
+to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display, communicate,
+  and translate a Work;
+
+  ii. moral rights retained by the original author(s) and/or performer(s);
+
+  iii. publicity and privacy rights pertaining to a person's image or likeness
+  depicted in a Work;
+
+  iv. rights protecting against unfair competition in regards to a Work,
+  subject to the limitations in paragraph 4(a), below;
+
+  v. rights protecting the extraction, dissemination, use and reuse of data in
+  a Work;
+
+  vi. database rights (such as those arising under Directive 96/9/EC of the
+  European Parliament and of the Council of 11 March 1996 on the legal
+  protection of databases, and under any national implementation thereof,
+  including any amended or successor version of such directive); and
+
+  vii. other similar, equivalent or corresponding rights throughout the world
+  based on applicable law or treaty, and any national implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention of,
+applicable law, Affirmer hereby overtly, fully, permanently, irrevocably and
+unconditionally waives, abandons, and surrenders all of Affirmer's Copyright
+and Related Rights and associated claims and causes of action, whether now
+known or unknown (including existing as well as future claims and causes of
+action), in the Work (i) in all territories worldwide, (ii) for the maximum
+duration provided by applicable law or treaty (including future time
+extensions), (iii) in any current or future medium and for any number of
+copies, and (iv) for any purpose whatsoever, including without limitation
+commercial, advertising or promotional purposes (the "Waiver"). Affirmer makes
+the Waiver for the benefit of each member of the public at large and to the
+detriment of Affirmer's heirs and successors, fully intending that such Waiver
+shall not be subject to revocation, rescission, cancellation, termination, or
+any other legal or equitable action to disrupt the quiet enjoyment of the Work
+by the public as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason be
+judged legally invalid or ineffective under applicable law, then the Waiver
+shall be preserved to the maximum extent permitted taking into account
+Affirmer's express Statement of Purpose. In addition, to the extent the Waiver
+is so judged Affirmer hereby grants to each affected person a royalty-free,
+non transferable, non sublicensable, non exclusive, irrevocable and
+unconditional license to exercise Affirmer's Copyright and Related Rights in
+the Work (i) in all territories worldwide, (ii) for the maximum duration
+provided by applicable law or treaty (including future time extensions), (iii)
+in any current or future medium and for any number of copies, and (iv) for any
+purpose whatsoever, including without limitation commercial, advertising or
+promotional purposes (the "License"). The License shall be deemed effective as
+of the date CC0 was applied by Affirmer to the Work. Should any part of the
+License for any reason be judged legally invalid or ineffective under
+applicable law, such partial invalidity or ineffectiveness shall not
+invalidate the remainder of the License, and in such case Affirmer hereby
+affirms that he or she will not (i) exercise any of his or her remaining
+Copyright and Related Rights in the Work or (ii) assert any associated claims
+and causes of action with respect to the Work, in either case contrary to
+Affirmer's express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+  a. No trademark or patent rights held by Affirmer are waived, abandoned,
+  surrendered, licensed or otherwise affected by this document.
+
+  b. Affirmer offers the Work as-is and makes no representations or warranties
+  of any kind concerning the Work, express, implied, statutory or otherwise,
+  including without limitation warranties of title, merchantability, fitness
+  for a particular purpose, non infringement, or the absence of latent or
+  other defects, accuracy, or the present or absence of errors, whether or not
+  discoverable, all to the greatest extent permissible under applicable law.
+
+  c. Affirmer disclaims responsibility for clearing rights of other persons
+  that may apply to the Work or any use thereof, including without limitation
+  any person's Copyright and Related Rights in the Work. Further, Affirmer
+  disclaims responsibility for obtaining any necessary consents, permissions
+  or other rights required for any use of the Work.
+
+  d. Affirmer understands and acknowledges that Creative Commons is not a
+  party to this document and has no duty or obligation with respect to this
+  CC0 or use of the Work.
+
+For more information, please see
+<http://creativecommons.org/publicdomain/zero/1.0/>

--- a/templates/account-wide-template.yaml
+++ b/templates/account-wide-template.yaml
@@ -1,0 +1,59 @@
+---
+  AWSTemplateFormatVersion: '2010-09-09'
+  Description: Setup for DevOpsGirsl Bootcamp 3. This is a generic account wide setup that will be shared by everyone.
+  Parameters:
+    VpcCIDR: 
+      Description: Please enter the IP range (CIDR notation) for this VPC
+      Type: String
+      Default: 10.192.0.0/16
+    PublicSubnetCIDR:
+      Description: Please enter the IP range (CIDR notation) for the public subnet in the first Availability Zone
+      Type: String
+      Default: 10.192.0.0/16                
+  Resources:
+    VPC: 
+      Type: AWS::EC2::VPC
+      Properties:
+          CidrBlock: !Ref VpcCIDR
+    InternetGateway:
+      Type: AWS::EC2::InternetGateway
+    InternetGatewayAttachment:
+      Type: AWS::EC2::VPCGatewayAttachment
+      Properties:
+          InternetGatewayId: !Ref InternetGateway
+          VpcId: !Ref VPC
+    PublicSubnet: 
+      Type: AWS::EC2::Subnet
+      Properties:
+          VpcId: !Ref VPC
+          AvailabilityZone: !Select [ 0, !GetAZs ]
+          CidrBlock: !Ref PublicSubnetCIDR
+          MapPublicIpOnLaunch: true
+    PublicRouteTable:
+      Type: AWS::EC2::RouteTable
+      Properties: 
+          VpcId: !Ref VPC        
+    DefaultPublicRoute: 
+      Type: AWS::EC2::Route
+      DependsOn: InternetGatewayAttachment
+      Properties: 
+          RouteTableId: !Ref PublicRouteTable
+          DestinationCidrBlock: 0.0.0.0/0
+          GatewayId: !Ref InternetGateway
+    PublicSubnetRouteTableAssociation:
+      Type: AWS::EC2::SubnetRouteTableAssociation
+      Properties:
+          RouteTableId: !Ref PublicRouteTable
+          SubnetId: !Ref PublicSubnet  
+  Outputs: 
+    VPC: 
+      Description: 'Generic VPC'
+      Value: !Ref VPC
+      Export:
+        Name: !Sub '${AWS::StackName}-VPC'
+    PublicSubnet:
+      Description: 'Public Subnet'
+      Value: !Ref PublicSubnet
+      Export:
+        Name: !Sub '${AWS::StackName}-PublicSubnet'
+    

--- a/templates/module2-ecs-static-site.yaml
+++ b/templates/module2-ecs-static-site.yaml
@@ -1,0 +1,347 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Setup for DevOpsGirsl Bootcamp 3, Module 2. ECS cluster in public subnet + CI setup
+Parameters:
+  SharedParentStack:
+    Description: 'The shared parent stack that has the VPC bits'
+    Type: String
+  InstanceType:
+    Description: Which instance type should we use to build the ECS cluster?
+    Type: String
+    Default: t2.micro
+  ClusterSize:
+      Description: How many ECS hosts do you want to initially deploy?
+      Type: Number
+      Default: 1
+Mappings:
+  AWSRegionToAMI:
+      us-east-2:
+          AMI: ami-ce1c36ab
+      us-east-1:
+          AMI: ami-28456852
+      us-west-2:
+          AMI: ami-decc7fa6
+      us-west-1:
+          AMI: ami-74262414
+      eu-west-3:
+          AMI: ami-9aef59e7
+      eu-west-2:
+          AMI: ami-67cbd003
+      eu-west-1:
+          AMI: ami-1d46df64
+      eu-central-1:
+          AMI: ami-509a053f
+      ap-northeast-2:
+          AMI: ami-c212b2ac
+      ap-northeast-1:
+          AMI: ami-872c4ae1
+      ap-southeast-2:
+          AMI: ami-58bb443a
+      ap-southeast-1:
+          AMI: ami-910d72ed
+      ca-central-1:
+          AMI: ami-435bde27
+      ap-south-1:
+          AMI: ami-00491f6f
+      sa-east-1:
+          AMI: ami-af521fc3
+              
+Resources:
+  ECRRepository:
+    Type: AWS::ECR::Repository
+    DeletionPolicy: Retain
+  ECSHostSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties: 
+        VpcId: 'Fn::ImportValue': !Sub '${ParentVPCStack}-VPC'
+        GroupDescription: 'ECS Host Security Group'
+        SecurityGroupIngress:
+            - SourceSecurityGroupId: !Ref LoadBalancerSecurityGroup 
+              IpProtocol: -1   
+            - IpProtocol: tcp
+              FromPort: '22'
+              ToPort: '22'
+              CidrIp: 0.0.0.0/0
+  LoadBalancerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties: 
+        VpcId: 'Fn::ImportValue': !Sub '${ParentVPCStack}-VPC'
+        GroupDescription: 'ALB Security Group'        
+        SecurityGroupIngress:
+            - CidrIp: 0.0.0.0/0
+              IpProtocol: -1              
+  ECSCluster:
+    Type: AWS::ECS::Cluster
+  ECSAutoScalingGroup:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+        VPCZoneIdentifier: 
+            - 'Fn::ImportValue': !Sub '${ParentVPCStack}-PublicSubnet'
+        LaunchConfigurationName: !Ref ECSLaunchConfiguration
+        MinSize: !Ref ClusterSize
+        MaxSize: !Ref ClusterSize
+        DesiredCapacity: !Ref ClusterSize
+  ECSLaunchConfiguration:
+    Type: AWS::AutoScaling::LaunchConfiguration
+    Properties:
+        ImageId:  !FindInMap [AWSRegionToAMI, !Ref "AWS::Region", AMI]
+        InstanceType: !Ref InstanceType
+        SecurityGroups:
+            - !Ref ECSHostSecurityGroup
+        IamInstanceProfile: !Ref ECSInstanceProfile
+        UserData:
+            "Fn::Base64": !Sub |
+                #!/bin/bash
+                yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+                yum install -y aws-cfn-bootstrap
+                /opt/aws/bin/cfn-init -v --region ${AWS::Region} --stack ${AWS::StackName} --resource ECSLaunchConfiguration
+                /opt/aws/bin/cfn-signal -e $? --region ${AWS::Region} --stack ${AWS::StackName} --resource ECSAutoScalingGroup
+    Metadata:
+        AWS::CloudFormation::Init:
+            config:
+                packages:
+                    yum:
+                        awslogs: []
+                commands:
+                    01_add_instance_to_cluster:
+                        command: !Sub echo ECS_CLUSTER=${ECSCluster} >> /etc/ecs/ecs.config
+                files:
+                    "/etc/cfn/cfn-hup.conf":
+                        mode: 000400
+                        owner: root
+                        group: root
+                        content: !Sub |
+                            [main]
+                            stack=${AWS::StackId}
+                            region=${AWS::Region}
+
+                    "/etc/cfn/hooks.d/cfn-auto-reloader.conf":
+                        content: !Sub |
+                            [cfn-auto-reloader-hook]
+                            triggers=post.update
+                            path=Resources.ECSLaunchConfiguration.Metadata.AWS::CloudFormation::Init
+                            action=/opt/aws/bin/cfn-init -v --region ${AWS::Region} --stack ${AWS::StackName} --resource ECSLaunchConfiguration
+                services:
+                    "/etc/awslogs/awscli.conf":
+                        content: !Sub |
+                            [plugins]
+                            cwlogs = cwlogs
+                            [default]
+                            region = ${AWS::Region}
+                    "/etc/awslogs/awslogs.conf":
+                        content: !Sub |
+                            [general]
+                            state_file = /var/lib/awslogs/agent-state
+
+                            [/var/log/dmesg]
+                            file = /var/log/dmesg
+                            log_group_name = ${ECSCluster}-/var/log/dmesg
+                            log_stream_name = ${ECSCluster}
+
+                            [/var/log/messages]
+                            file = /var/log/messages
+                            log_group_name = ${ECSCluster}-/var/log/messages
+                            log_stream_name = ${ECSCluster}
+                            datetime_format = %b %d %H:%M:%S
+
+                            [/var/log/docker]
+                            file = /var/log/docker
+                            log_group_name = ${ECSCluster}-/var/log/docker
+                            log_stream_name = ${ECSCluster}
+                            datetime_format = %Y-%m-%dT%H:%M:%S.%f
+
+                            [/var/log/ecs/ecs-init.log]
+                            file = /var/log/ecs/ecs-init.log.*
+                            log_group_name = ${ECSCluster}-/var/log/ecs/ecs-init.log
+                            log_stream_name = ${ECSCluster}
+                            datetime_format = %Y-%m-%dT%H:%M:%SZ
+
+                            [/var/log/ecs/ecs-agent.log]
+                            file = /var/log/ecs/ecs-agent.log.*
+                            log_group_name = ${ECSCluster}-/var/log/ecs/ecs-agent.log
+                            log_stream_name = ${ECSCluster}
+                            datetime_format = %Y-%m-%dT%H:%M:%SZ
+
+                            [/var/log/ecs/audit.log]
+                            file = /var/log/ecs/audit.log.*
+                            log_group_name = ${ECSCluster}-/var/log/ecs/audit.log
+                            log_stream_name = ${ECSCluster}
+                            datetime_format = %Y-%m-%dT%H:%M:%SZ
+                    sysvinit:
+                        cfn-hup:
+                            enabled: true
+                            ensureRunning: true
+                            files:
+                                - /etc/cfn/cfn-hup.conf
+                                - /etc/cfn/hooks.d/cfn-auto-reloader.conf
+                        awslogs:
+                            enabled: true
+                            ensureRunning: true
+                            files:
+                                - /etc/awslogs/awslogs.conf
+                                - /etc/awslogs/awscli.conf
+  ECSRole:
+    Type: AWS::IAM::Role
+    Properties:
+        Path: /
+        AssumeRolePolicyDocument: |
+            {
+                "Statement": [{
+                    "Action": "sts:AssumeRole",
+                    "Effect": "Allow",
+                    "Principal": {
+                        "Service": "ec2.amazonaws.com"
+                    }
+                }]
+            }
+        Policies:
+            - PolicyName: ecs-service
+            PolicyDocument: |
+                {
+                    "Statement": [{
+                        "Effect": "Allow",
+                        "Action": [
+                            "ecs:CreateCluster",
+                            "ecs:DeregisterContainerInstance",
+                            "ecs:DiscoverPollEndpoint",
+                            "ecs:Poll",
+                            "ecs:RegisterContainerInstance",
+                            "ecs:StartTelemetrySession",
+                            "ecs:Submit*",
+                            "ecr:BatchCheckLayerAvailability",
+                            "ecr:BatchGetImage",
+                            "ecr:GetDownloadUrlForLayer",
+                            "ecr:GetAuthorizationToken",
+                            "cloudwatch:PutMetricData",
+                            "ec2:DescribeInstanceStatus",
+                            "logs:CreateLogGroup",
+                            "logs:CreateLogStream",
+                            "logs:DescribeLogGroups",
+                            "logs:DescribeLogStreams",
+                            "logs:PutLogEvents",
+                            "s3:PutObject",
+                            "s3:GetObject",
+                            "s3:ListBucket"
+                        ],
+                        "Resource": "*"
+                    }]
+                }
+  ECSInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+        Path: /
+        Roles:
+            - !Ref ECSRole
+  Module2ArtifactBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Delete
+    Properties:
+        AccessControl: Private            
+  Module2CodePipelineRolePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+        PolicyName: Module3CodePipelineRolePolicy
+        PolicyDocument:
+        Statement:
+        - Action:
+            - s3:GetObject
+            - s3:PutObject
+            - s3:GetObjectVersion
+            - s3:GetBucketVersioning
+            Resource:
+                - !Sub 'arn:aws:s3:::${Module2ArtifactBucket}'
+                - !Sub 'arn:aws:s3:::${Module2ArtifactBucket}/*'
+            Effect: Allow
+        - Action:
+            - codebuild:BatchGetBuilds
+            - codebuild:StartBuild
+            Resource: '*'
+            Effect: Allow
+        - Action:
+            - ecs:DescribeServices
+            - ecs:DescribeTaskDefinition
+            - ecs:DescribeTasks
+            - ecs:ListTasks
+            - ecs:RegisterTaskDefinition
+            - ecs:UpdateService
+            Resource: !Sub 'arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${ECSCLuster}'
+            Effect: Allow            
+        - Action:
+            - codecommit:GetBranch
+            - codecommit:GetCommit 
+            - codecommit:UploadArchive
+            - codecommit:GetUploadArchiveStatus
+            - codecommit:CancelUploadArchive
+            Resource: !Sub 'arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:${CodeCommitRepo.Name}'
+            Effect: Allow          
+        Roles:
+        - !Ref 'Module2CodePipelineRole'
+  Module2CodePipelineRole:
+    Type: AWS::IAM::Role
+    Properties:
+        AssumeRolePolicyDocument:
+        Statement:
+        - Sid: ''
+            Effect: Allow
+            Principal:
+            Service:
+            - codepipeline.amazonaws.com
+            Action: sts:AssumeRole
+        Path: /
+  Module2CodeBuildRole:
+    Type: AWS::IAM::Role
+    Properties:
+        AssumeRolePolicyDocument:
+        Statement:
+        - Sid: ''
+            Effect: Allow
+            Principal:
+            Service:
+            - codebuild.amazonaws.com
+            Action: sts:AssumeRole
+        Path: /
+  Module2CodeBuildRolePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+        PolicyName: Module2CodeBuildRolePolicy
+        PolicyDocument:
+        Statement:
+        - Effect: Allow
+            Resource:
+            - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/*'
+            Action:
+            - logs:CreateLogGroup
+            - logs:CreateLogStream
+            - logs:PutLogEvents
+        - Effect: Allow
+            Resource:
+            - !Sub 'arn:aws:s3:::${Module3ArtifactBucket}'
+            - !Sub 'arn:aws:s3:::${Module3ArtifactBucket}/*'
+            - !Sub 'arn:aws:s3:::${StaticSiteBucket}'
+            - !Sub 'arn:aws:s3:::${StaticSiteBucket}/*'
+            Action:
+            - s3:GetObject
+            - s3:PutObject
+            - s3:GetObjectVersion
+        - Effect: Allow
+            Resource:
+            - !Sub arn:aws:ecr:${AWS::Region}:${AWS::AccountId}:repository/${ECRRepository}
+            Action:
+            - ecr:GetDownloadUrlForLayer
+            - ecr:BatchGetImage
+            - ecr:BatchCheckLayerAvailability
+            - ecr:PutImage
+            - ecr:InitiateLayerUpload
+            - ecr:UploadLayerPart
+            - ecr:CompleteLayerUpload    
+        - Effect: Allow
+            Resource: '*'
+            Action:
+            - ecr:GetAuthorizationToken                   
+        Roles:
+        - !Ref 'Module2CodeBuildRole'    
+Outputs: 
+  VPC: 
+      Description: A reference to the created VPC
+      Value: !Ref VPC
+  

--- a/templates/module3-serverless-static-site.yaml
+++ b/templates/module3-serverless-static-site.yaml
@@ -1,0 +1,178 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Setup for DevOpsGirsl Bootcamp 3, Module 3. CI for static site hosted in S3.
+Parameters:
+  GitRepo:
+    Type: String
+    Description: Name of the git repo that holds the static website 
+  GitRepoDescription:
+    Type: String
+    Description: Description of the git repo   
+  SiteBucketName:
+    Type: String
+    Description: Name of bucket to create to host the website
+Resources:
+  CodeCommitRepo:
+    Type: AWS::CodeCommit::Repository
+    Properties:
+      RepositoryName: !Ref GitRepo
+      RepositoryDescription: !Ref GitRepoDescription
+  Module3ArtifactBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Delete
+    Properties:
+      AccessControl: Private
+  StaticSiteBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Delete
+    Properties:
+      AccessControl: PublicRead
+      BucketName: !Ref SiteBucketName
+      WebsiteConfiguration:
+        IndexDocument: index.html
+  Module3CodeBuildRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Sid: ''
+          Effect: Allow
+          Principal:
+            Service:
+            - codebuild.amazonaws.com
+          Action: sts:AssumeRole
+      Path: /
+  Module3CodeBuildRolePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: Module3CodeBuildRolePolicy
+      PolicyDocument:
+        Statement:
+        - Effect: Allow
+          Resource:
+          - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/*'
+          Action:
+          - logs:CreateLogGroup
+          - logs:CreateLogStream
+          - logs:PutLogEvents
+        - Effect: Allow
+          Resource:
+          - !Sub 'arn:aws:s3:::${Module3ArtifactBucket}'
+          - !Sub 'arn:aws:s3:::${Module3ArtifactBucket}/*'
+          - !Sub 'arn:aws:s3:::${StaticSiteBucket}'
+          - !Sub 'arn:aws:s3:::${StaticSiteBucket}/*'
+          Action:
+          - s3:*
+      Roles:
+      - !Ref 'Module3CodeBuildRole'
+  CodeBuildDeploySite:
+    Type: AWS::CodeBuild::Project
+    DependsOn: Module3CodeBuildRole
+    Properties:
+      Name: !Sub ${AWS::StackName}-DeployStaticSite
+      Description: Deploy site to S3
+      ServiceRole: !GetAtt Module3CodeBuildRole.Arn
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/ubuntu-base:14.04
+        Type: LINUX_CONTAINER
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: !Sub |
+          version: 0.1
+          phases:
+            post_build:
+              commands:
+                - ls -al
+                - aws s3 cp --acl public-read index.html s3://${SiteBucketName}/ 
+      TimeoutInMinutes: 10
+  Module3CodePipelineRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Sid: ''
+          Effect: Allow
+          Principal:
+            Service:
+            - codepipeline.amazonaws.com
+          Action: sts:AssumeRole
+      Path: /
+  Module3CodePipelineRolePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: Module3CodePipelineRolePolicy
+      PolicyDocument:
+        Statement:
+        - Action:
+          - s3:GetObject
+          - s3:GetObjectVersion
+          - s3:GetBucketVersioning
+          Resource: '*'
+          Effect: Allow
+        - Action:
+          - s3:PutObject
+          Resource:
+          - !Sub 'arn:aws:s3:::${Module3ArtifactBucket}'
+          - !Sub 'arn:aws:s3:::${Module3ArtifactBucket}/*'
+          Effect: Allow
+        - Action:
+          - codebuild:BatchGetBuilds
+          - codebuild:StartBuild
+          Resource: '*'
+          Effect: Allow
+        - Action:
+          - codecommit:GetBranch
+          - codecommit:GetCommit 
+          - codecommit:UploadArchive
+          - codecommit:GetUploadArchiveStatus
+          - codecommit:CancelUploadArchive
+          Resource: !Sub 'arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:${CodeCommitRepo.Name}'
+          Effect: Allow          
+      Roles:
+      - !Ref 'Module3CodePipelineRole'
+  Module3Pipeline:
+    Type: AWS::CodePipeline::Pipeline
+    Properties:
+      RoleArn: !GetAtt Module3CodePipelineRole.Arn
+      Stages:
+      - Name: Source
+        Actions:
+        - InputArtifacts: []
+          Name: Source
+          ActionTypeId:
+            Category: Source
+            Owner: AWS
+            Version: '1'
+            Provider: CodeCommit
+          OutputArtifacts:
+          - Name: SourceOutput
+          Configuration:
+            RepositoryName: !GetAtt CodeCommitRepo.Name
+            BranchName: 'master'
+          RunOrder: 1
+      - Name: Deploy
+        Actions:
+        - Name: Artifact
+          ActionTypeId:
+            Category: Build
+            Owner: AWS
+            Version: '1'
+            Provider: CodeBuild
+          InputArtifacts:
+          - Name: SourceOutput
+          OutputArtifacts:
+          - Name: DeployOutput
+          Configuration:
+            ProjectName: !Ref CodeBuildDeploySite
+          RunOrder: 1
+      ArtifactStore:
+        Type: S3
+        Location: !Ref Module3ArtifactBucket
+Outputs:
+  SiteUrl:
+    Value: !GetAtt [StaticSiteBucket, WebsiteURL]
+    Description: S3 Website URL
+


### PR DESCRIPTION
* Copied the license over from devopsgirls-bootcamp
* First draft of cfn templates
  * account-wide-template.yaml - VPC, Public Subnet, IGW routes etc
  * module2-ecs-static-site.yaml - ECS Cluster and has roles for CodeBuild and CodePipeline
  * module3-serverless-static-site.yaml - End to end deploy of static site from CodeCommit to S3.

Notes :
- The CodeCommit repo in ` module3-serverless-static-site.yaml` should probably moved out to a attendee-initial-setup template
- Do not have R53 setup yet. Could possibly add R53 health checks and alarms. But parking that decision till we collect rest of material. It might be too much content.